### PR TITLE
Hotfix 1.2.2 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.2 (2022-02-28)
+------------------
+
+**Added**
+
+**Fixed**
+
+* CVE-2020-25638
+
+**Dependencies**
+
+* ``org.hibernate:hibernate-core:3.5.6-Final`` -> ``5.6.5.Final``
+
+**Deprecated**
+
 1.2.1 (2021-06-08)
 ------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>life.qbic</groupId>
 	<artifactId>omero-client-lib</artifactId>
-	<version>1.2.1</version>
+	<version>1.2.2</version>
 	<name>OMERO client library</name>
 	<url>http://github.com/qbicsoftware/omero-lib</url>
 	<description>OMERO client library - A Java-based library to access an OMERO server</description>
@@ -158,7 +158,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>3.5.6-Final</version>
+				<version>5.4.24.Final</version>
 			</dependency>
 			<!-- Using Bio-Formats official POMs rather than Ivy ones -->
 			<dependency>


### PR DESCRIPTION
1.2.2 (2022-02-28)
------------------

**Added**

**Fixed**

* CVE-2020-25638

**Dependencies**

* ``org.hibernate:hibernate-core:3.5.6-Final`` -> ``5.6.5.Final``

**Deprecated**
